### PR TITLE
Improve testcases for #rk3 and #fz7

### DIFF
--- a/internal/stage_negative_character_groups.go
+++ b/internal/stage_negative_character_groups.go
@@ -14,6 +14,11 @@ func testNegativeCharacterGroups(stageHarness *test_case_harness.TestCaseHarness
 			Input:            "banana",
 			ExpectedExitCode: 1,
 		},
+		{
+			Pattern:          "[^opq]",
+			Input:            "orange",
+			ExpectedExitCode: 0,
+		},
 	}
 
 	return RunTestCases(testCases, stageHarness)

--- a/internal/stage_one_or_more_quantifier.go
+++ b/internal/stage_one_or_more_quantifier.go
@@ -8,12 +8,12 @@ func testOneOrMoreQuantifier(stageHarness *test_case_harness.TestCaseHarness) er
 	testCases := []TestCase{
 		{
 			Pattern:          "ca+t",
-			Input:            "caaats",
+			Input:            "cat",
 			ExpectedExitCode: 0,
 		},
 		{
-			Pattern:          "ca+t",
-			Input:            "cat",
+			Pattern:          "ca+at",
+			Input:            "caaats",
 			ExpectedExitCode: 0,
 		},
 		{

--- a/internal/test_helpers/fixtures/alternation/success
+++ b/internal/test_helpers/fixtures/alternation/success
@@ -36,11 +36,11 @@
 [33m[stage-10] [0m[92mTest passed.[0m
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: fz7[0m
-[33m[stage-9] [0m[94m$ echo -n "caaats" | ./your_grep.sh -E "ca+t"[0m
-[33m[your_program] [0mcaaats
-[33m[stage-9] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [0m[94m$ echo -n "cat" | ./your_grep.sh -E "ca+t"[0m
 [33m[your_program] [0mcat
+[33m[stage-9] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-9] [0m[94m$ echo -n "caaats" | ./your_grep.sh -E "ca+at"[0m
+[33m[your_program] [0mcaaats
 [33m[stage-9] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [0m[94m$ echo -n "act" | ./your_grep.sh -E "ca+t"[0m
 [33m[stage-9] [0m[92m✓ Received exit code 1.[0m
@@ -91,6 +91,9 @@
 [33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[94m$ echo -n "banana" | ./your_grep.sh -E "[^anb]"[0m
 [33m[stage-5] [0m[92m✓ Received exit code 1.[0m
+[33m[stage-5] [0m[94m$ echo -n "orange" | ./your_grep.sh -E "[^opq]"[0m
+[33m[your_program] [0morange
+[33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: tl6[0m

--- a/internal/test_helpers/fixtures/backreferences_multiple/success
+++ b/internal/test_helpers/fixtures/backreferences_multiple/success
@@ -118,11 +118,11 @@
 [33m[stage-10] [0m[92mTest passed.[0m
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: fz7[0m
-[33m[stage-9] [0m[94m$ echo -n "caaats" | ./your_grep.sh -E "ca+t"[0m
-[33m[your_program] [0mcaaats
-[33m[stage-9] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [0m[94m$ echo -n "cat" | ./your_grep.sh -E "ca+t"[0m
 [33m[your_program] [0mcat
+[33m[stage-9] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-9] [0m[94m$ echo -n "caaats" | ./your_grep.sh -E "ca+at"[0m
+[33m[your_program] [0mcaaats
 [33m[stage-9] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [0m[94m$ echo -n "act" | ./your_grep.sh -E "ca+t"[0m
 [33m[stage-9] [0m[92m✓ Received exit code 1.[0m
@@ -173,6 +173,9 @@
 [33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[94m$ echo -n "banana" | ./your_grep.sh -E "[^anb]"[0m
 [33m[stage-5] [0m[92m✓ Received exit code 1.[0m
+[33m[stage-5] [0m[94m$ echo -n "orange" | ./your_grep.sh -E "[^opq]"[0m
+[33m[your_program] [0morange
+[33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: tl6[0m

--- a/internal/test_helpers/fixtures/backreferences_nested/success
+++ b/internal/test_helpers/fixtures/backreferences_nested/success
@@ -159,11 +159,11 @@
 [33m[stage-10] [0m[92mTest passed.[0m
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: fz7[0m
-[33m[stage-9] [0m[94m$ echo -n "caaats" | ./your_grep.sh -E "ca+t"[0m
-[33m[your_program] [0mcaaats
-[33m[stage-9] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [0m[94m$ echo -n "cat" | ./your_grep.sh -E "ca+t"[0m
 [33m[your_program] [0mcat
+[33m[stage-9] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-9] [0m[94m$ echo -n "caaats" | ./your_grep.sh -E "ca+at"[0m
+[33m[your_program] [0mcaaats
 [33m[stage-9] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [0m[94m$ echo -n "act" | ./your_grep.sh -E "ca+t"[0m
 [33m[stage-9] [0m[92m✓ Received exit code 1.[0m
@@ -214,6 +214,9 @@
 [33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[94m$ echo -n "banana" | ./your_grep.sh -E "[^anb]"[0m
 [33m[stage-5] [0m[92m✓ Received exit code 1.[0m
+[33m[stage-5] [0m[94m$ echo -n "orange" | ./your_grep.sh -E "[^opq]"[0m
+[33m[your_program] [0morange
+[33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: tl6[0m

--- a/internal/test_helpers/fixtures/backreferences_single/success
+++ b/internal/test_helpers/fixtures/backreferences_single/success
@@ -77,11 +77,11 @@
 [33m[stage-10] [0m[92mTest passed.[0m
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: fz7[0m
-[33m[stage-9] [0m[94m$ echo -n "caaats" | ./your_grep.sh -E "ca+t"[0m
-[33m[your_program] [0mcaaats
-[33m[stage-9] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [0m[94m$ echo -n "cat" | ./your_grep.sh -E "ca+t"[0m
 [33m[your_program] [0mcat
+[33m[stage-9] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-9] [0m[94m$ echo -n "caaats" | ./your_grep.sh -E "ca+at"[0m
+[33m[your_program] [0mcaaats
 [33m[stage-9] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [0m[94m$ echo -n "act" | ./your_grep.sh -E "ca+t"[0m
 [33m[stage-9] [0m[92m✓ Received exit code 1.[0m
@@ -132,6 +132,9 @@
 [33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[94m$ echo -n "banana" | ./your_grep.sh -E "[^anb]"[0m
 [33m[stage-5] [0m[92m✓ Received exit code 1.[0m
+[33m[stage-5] [0m[94m$ echo -n "orange" | ./your_grep.sh -E "[^opq]"[0m
+[33m[your_program] [0morange
+[33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: tl6[0m

--- a/internal/test_helpers/fixtures/combining_character_classes/success
+++ b/internal/test_helpers/fixtures/combining_character_classes/success
@@ -25,6 +25,9 @@
 [33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[94m$ echo -n "banana" | ./your_grep.sh -E "[^anb]"[0m
 [33m[stage-5] [0m[92m✓ Received exit code 1.[0m
+[33m[stage-5] [0m[94m$ echo -n "orange" | ./your_grep.sh -E "[^opq]"[0m
+[33m[your_program] [0morange
+[33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: tl6[0m

--- a/internal/test_helpers/fixtures/end_of_string_anchor/success
+++ b/internal/test_helpers/fixtures/end_of_string_anchor/success
@@ -41,6 +41,9 @@
 [33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[94m$ echo -n "banana" | ./your_grep.sh -E "[^anb]"[0m
 [33m[stage-5] [0m[92m✓ Received exit code 1.[0m
+[33m[stage-5] [0m[94m$ echo -n "orange" | ./your_grep.sh -E "[^opq]"[0m
+[33m[your_program] [0morange
+[33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: tl6[0m

--- a/internal/test_helpers/fixtures/negative_character_groups/success
+++ b/internal/test_helpers/fixtures/negative_character_groups/success
@@ -4,6 +4,9 @@
 [33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[94m$ echo -n "banana" | ./your_grep.sh -E "[^anb]"[0m
 [33m[stage-5] [0m[92m✓ Received exit code 1.[0m
+[33m[stage-5] [0m[94m$ echo -n "orange" | ./your_grep.sh -E "[^opq]"[0m
+[33m[your_program] [0morange
+[33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: tl6[0m

--- a/internal/test_helpers/fixtures/one_or_more_quantifier/success
+++ b/internal/test_helpers/fixtures/one_or_more_quantifier/success
@@ -1,9 +1,9 @@
 [33m[stage-9] [0m[94mRunning tests for Stage #9: fz7[0m
-[33m[stage-9] [0m[94m$ echo -n "caaats" | ./your_grep.sh -E "ca+t"[0m
-[33m[your_program] [0mcaaats
-[33m[stage-9] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [0m[94m$ echo -n "cat" | ./your_grep.sh -E "ca+t"[0m
 [33m[your_program] [0mcat
+[33m[stage-9] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-9] [0m[94m$ echo -n "caaats" | ./your_grep.sh -E "ca+at"[0m
+[33m[your_program] [0mcaaats
 [33m[stage-9] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [0m[94m$ echo -n "act" | ./your_grep.sh -E "ca+t"[0m
 [33m[stage-9] [0m[92m✓ Received exit code 1.[0m
@@ -54,6 +54,9 @@
 [33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[94m$ echo -n "banana" | ./your_grep.sh -E "[^anb]"[0m
 [33m[stage-5] [0m[92m✓ Received exit code 1.[0m
+[33m[stage-5] [0m[94m$ echo -n "orange" | ./your_grep.sh -E "[^opq]"[0m
+[33m[your_program] [0morange
+[33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: tl6[0m

--- a/internal/test_helpers/fixtures/start_of_string_anchor/success
+++ b/internal/test_helpers/fixtures/start_of_string_anchor/success
@@ -33,6 +33,9 @@
 [33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[94m$ echo -n "banana" | ./your_grep.sh -E "[^anb]"[0m
 [33m[stage-5] [0m[92m✓ Received exit code 1.[0m
+[33m[stage-5] [0m[94m$ echo -n "orange" | ./your_grep.sh -E "[^opq]"[0m
+[33m[your_program] [0morange
+[33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: tl6[0m

--- a/internal/test_helpers/fixtures/wildcard/success
+++ b/internal/test_helpers/fixtures/wildcard/success
@@ -25,11 +25,11 @@
 [33m[stage-10] [0m[92mTest passed.[0m
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: fz7[0m
-[33m[stage-9] [0m[94m$ echo -n "caaats" | ./your_grep.sh -E "ca+t"[0m
-[33m[your_program] [0mcaaats
-[33m[stage-9] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [0m[94m$ echo -n "cat" | ./your_grep.sh -E "ca+t"[0m
 [33m[your_program] [0mcat
+[33m[stage-9] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-9] [0m[94m$ echo -n "caaats" | ./your_grep.sh -E "ca+at"[0m
+[33m[your_program] [0mcaaats
 [33m[stage-9] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [0m[94m$ echo -n "act" | ./your_grep.sh -E "ca+t"[0m
 [33m[stage-9] [0m[92m✓ Received exit code 1.[0m
@@ -80,6 +80,9 @@
 [33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[94m$ echo -n "banana" | ./your_grep.sh -E "[^anb]"[0m
 [33m[stage-5] [0m[92m✓ Received exit code 1.[0m
+[33m[stage-5] [0m[94m$ echo -n "orange" | ./your_grep.sh -E "[^opq]"[0m
+[33m[your_program] [0morange
+[33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: tl6[0m

--- a/internal/test_helpers/fixtures/zero_or_one_quantifier/success
+++ b/internal/test_helpers/fixtures/zero_or_one_quantifier/success
@@ -12,11 +12,11 @@
 [33m[stage-10] [0m[92mTest passed.[0m
 
 [33m[stage-9] [0m[94mRunning tests for Stage #9: fz7[0m
-[33m[stage-9] [0m[94m$ echo -n "caaats" | ./your_grep.sh -E "ca+t"[0m
-[33m[your_program] [0mcaaats
-[33m[stage-9] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [0m[94m$ echo -n "cat" | ./your_grep.sh -E "ca+t"[0m
 [33m[your_program] [0mcat
+[33m[stage-9] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-9] [0m[94m$ echo -n "caaats" | ./your_grep.sh -E "ca+at"[0m
+[33m[your_program] [0mcaaats
 [33m[stage-9] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [0m[94m$ echo -n "act" | ./your_grep.sh -E "ca+t"[0m
 [33m[stage-9] [0m[92m✓ Received exit code 1.[0m
@@ -67,6 +67,9 @@
 [33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[94m$ echo -n "banana" | ./your_grep.sh -E "[^anb]"[0m
 [33m[stage-5] [0m[92m✓ Received exit code 1.[0m
+[33m[stage-5] [0m[94m$ echo -n "orange" | ./your_grep.sh -E "[^opq]"[0m
+[33m[your_program] [0morange
+[33m[stage-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: tl6[0m


### PR DESCRIPTION
Member suggested testcases:

>echo -n "apple" | ./your_program.sh -E "[^abc]"
echo -n "apple" | ./your_program.sh -E "[^p]"
>
>echo -n "apple" | ./your_program.sh -E "ap+p"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded real-world test coverage for pattern matching, ensuring reliable and consistent outcomes.
  - Refined existing test scenarios by replacing legacy regex cases with more robust alternatives.
  - Introduced additional test cases addressing diverse pattern scenarios to further enhance overall validation of regex functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->