### PR TITLE
Harden testcase #tl6 Positive Character Groups 

### DIFF
--- a/internal/stage_positive_character_groups.go
+++ b/internal/stage_positive_character_groups.go
@@ -12,7 +12,7 @@ func testPositiveCharacterGroups(stageHarness *test_case_harness.TestCaseHarness
 	words := random.RandomWords(3)
 
 	letterInsideWord0 := random.RandomElementFromArray(strings.Split(words[0], ""))
-	letterOutsideWord1 := pickLetterOutsideWord(words[1], len(words[1]))
+	lettersOutsideWord1 := pickLettersOutsideWord(words[1], len(words[1]))
 
 	testCases := []TestCase{
 		{
@@ -22,7 +22,7 @@ func testPositiveCharacterGroups(stageHarness *test_case_harness.TestCaseHarness
 		},
 		{
 			Pattern:          fmt.Sprintf("[%s]", words[1]),
-			Input:            letterOutsideWord1,
+			Input:            lettersOutsideWord1,
 			ExpectedExitCode: 1,
 		},
 		{
@@ -35,7 +35,7 @@ func testPositiveCharacterGroups(stageHarness *test_case_harness.TestCaseHarness
 	return RunTestCases(testCases, stageHarness)
 }
 
-func pickLetterOutsideWord(word string, n int) string {
+func pickLettersOutsideWord(word string, n int) string {
 	letters := ""
 
 	for x := 'a'; x <= 'z'; x++ {

--- a/internal/stage_positive_character_groups.go
+++ b/internal/stage_positive_character_groups.go
@@ -1,25 +1,51 @@
 package internal
 
-import "github.com/codecrafters-io/tester-utils/test_case_harness"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
 
 func testPositiveCharacterGroups(stageHarness *test_case_harness.TestCaseHarness) error {
+	words := random.RandomWords(3)
+
+	letterInsideWord0 := random.RandomElementFromArray(strings.Split(words[0], ""))
+	letterOutsideWord1 := pickLetterOutsideWord(words[1], len(words[1]))
+
 	testCases := []TestCase{
 		{
-			Pattern:          "[abcd]",
-			Input:            "a",
+			Pattern:          fmt.Sprintf("[%s]", words[0]),
+			Input:            letterInsideWord0,
 			ExpectedExitCode: 0,
 		},
 		{
-			Pattern:          "[abcd]",
-			Input:            "efgh",
+			Pattern:          fmt.Sprintf("[%s]", words[1]),
+			Input:            letterOutsideWord1,
 			ExpectedExitCode: 1,
 		},
 		{
-			Pattern:          "[abcd]",
+			Pattern:          fmt.Sprintf("[%s]", words[2]),
 			Input:            "[]",
 			ExpectedExitCode: 1,
 		},
 	}
 
 	return RunTestCases(testCases, stageHarness)
+}
+
+func pickLetterOutsideWord(word string, n int) string {
+	letters := ""
+
+	for x := 'a'; x <= 'z'; x++ {
+		if !strings.Contains(word, string(x)) {
+			letters += string(x)
+		}
+		if len(letters) >= n {
+			break
+		}
+	}
+
+	return letters
 }

--- a/internal/stage_positive_character_groups.go
+++ b/internal/stage_positive_character_groups.go
@@ -21,8 +21,8 @@ func testPositiveCharacterGroups(stageHarness *test_case_harness.TestCaseHarness
 			ExpectedExitCode: 0,
 		},
 		{
-			Pattern:          fmt.Sprintf("[%s]", words[1]),
-			Input:            lettersOutsideWord1,
+			Pattern:          fmt.Sprintf("[%s]", lettersOutsideWord1),
+			Input:            words[1],
 			ExpectedExitCode: 1,
 		},
 		{

--- a/internal/stage_positive_character_groups.go
+++ b/internal/stage_positive_character_groups.go
@@ -14,6 +14,11 @@ func testPositiveCharacterGroups(stageHarness *test_case_harness.TestCaseHarness
 			Input:            "efgh",
 			ExpectedExitCode: 1,
 		},
+		{
+			Pattern:          "[abcd]",
+			Input:            "[]",
+			ExpectedExitCode: 1,
+		},
 	}
 
 	return RunTestCases(testCases, stageHarness)

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -1,12 +1,14 @@
 package internal
 
 import (
+	"os"
 	"testing"
 
 	tester_utils_testing "github.com/codecrafters-io/tester-utils/testing"
 )
 
 func TestStages(t *testing.T) {
+	os.Setenv("CODECRAFTERS_RANDOM_SEED", "1234567890")
 
 	falseVar := false
 

--- a/internal/test_helpers/fixtures/alternation/success
+++ b/internal/test_helpers/fixtures/alternation/success
@@ -105,7 +105,7 @@
 [33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
 [33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "blueberry" | ./your_grep.sh -E "[acdfghijk]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m

--- a/internal/test_helpers/fixtures/alternation/success
+++ b/internal/test_helpers/fixtures/alternation/success
@@ -107,6 +107,8 @@
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 
 [33m[tester::#MR9] [0m[94mRunning tests for Stage #MR9 (mr9)[0m

--- a/internal/test_helpers/fixtures/alternation/success
+++ b/internal/test_helpers/fixtures/alternation/success
@@ -102,12 +102,12 @@
 [33m[tester::#RK3] [0m[92mTest passed.[0m
 
 [33m[tester::#TL6] [0m[94mRunning tests for Stage #TL6 (tl6)[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "a" | ./your_grep.sh -E "[abcd]"[0m
-[33m[your_program] [0ma
+[33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
+[33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 

--- a/internal/test_helpers/fixtures/backreferences_multiple/success
+++ b/internal/test_helpers/fixtures/backreferences_multiple/success
@@ -187,7 +187,7 @@
 [33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
 [33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "blueberry" | ./your_grep.sh -E "[acdfghijk]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m

--- a/internal/test_helpers/fixtures/backreferences_multiple/success
+++ b/internal/test_helpers/fixtures/backreferences_multiple/success
@@ -184,12 +184,12 @@
 [33m[tester::#RK3] [0m[92mTest passed.[0m
 
 [33m[tester::#TL6] [0m[94mRunning tests for Stage #TL6 (tl6)[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "a" | ./your_grep.sh -E "[abcd]"[0m
-[33m[your_program] [0ma
+[33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
+[33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 

--- a/internal/test_helpers/fixtures/backreferences_multiple/success
+++ b/internal/test_helpers/fixtures/backreferences_multiple/success
@@ -189,6 +189,8 @@
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 
 [33m[tester::#MR9] [0m[94mRunning tests for Stage #MR9 (mr9)[0m

--- a/internal/test_helpers/fixtures/backreferences_nested/success
+++ b/internal/test_helpers/fixtures/backreferences_nested/success
@@ -225,12 +225,12 @@
 [33m[tester::#RK3] [0m[92mTest passed.[0m
 
 [33m[tester::#TL6] [0m[94mRunning tests for Stage #TL6 (tl6)[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "a" | ./your_grep.sh -E "[abcd]"[0m
-[33m[your_program] [0ma
+[33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
+[33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 

--- a/internal/test_helpers/fixtures/backreferences_nested/success
+++ b/internal/test_helpers/fixtures/backreferences_nested/success
@@ -228,7 +228,7 @@
 [33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
 [33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "blueberry" | ./your_grep.sh -E "[acdfghijk]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m

--- a/internal/test_helpers/fixtures/backreferences_nested/success
+++ b/internal/test_helpers/fixtures/backreferences_nested/success
@@ -230,6 +230,8 @@
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 
 [33m[tester::#MR9] [0m[94mRunning tests for Stage #MR9 (mr9)[0m

--- a/internal/test_helpers/fixtures/backreferences_single/success
+++ b/internal/test_helpers/fixtures/backreferences_single/success
@@ -143,12 +143,12 @@
 [33m[tester::#RK3] [0m[92mTest passed.[0m
 
 [33m[tester::#TL6] [0m[94mRunning tests for Stage #TL6 (tl6)[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "a" | ./your_grep.sh -E "[abcd]"[0m
-[33m[your_program] [0ma
+[33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
+[33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 

--- a/internal/test_helpers/fixtures/backreferences_single/success
+++ b/internal/test_helpers/fixtures/backreferences_single/success
@@ -148,6 +148,8 @@
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 
 [33m[tester::#MR9] [0m[94mRunning tests for Stage #MR9 (mr9)[0m

--- a/internal/test_helpers/fixtures/backreferences_single/success
+++ b/internal/test_helpers/fixtures/backreferences_single/success
@@ -146,7 +146,7 @@
 [33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
 [33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "blueberry" | ./your_grep.sh -E "[acdfghijk]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m

--- a/internal/test_helpers/fixtures/combining_character_classes/success
+++ b/internal/test_helpers/fixtures/combining_character_classes/success
@@ -39,6 +39,8 @@
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 
 [33m[tester::#MR9] [0m[94mRunning tests for Stage #MR9 (mr9)[0m

--- a/internal/test_helpers/fixtures/combining_character_classes/success
+++ b/internal/test_helpers/fixtures/combining_character_classes/success
@@ -34,12 +34,12 @@
 [33m[tester::#RK3] [0m[92mTest passed.[0m
 
 [33m[tester::#TL6] [0m[94mRunning tests for Stage #TL6 (tl6)[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "a" | ./your_grep.sh -E "[abcd]"[0m
-[33m[your_program] [0ma
+[33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
+[33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 

--- a/internal/test_helpers/fixtures/combining_character_classes/success
+++ b/internal/test_helpers/fixtures/combining_character_classes/success
@@ -37,7 +37,7 @@
 [33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
 [33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "blueberry" | ./your_grep.sh -E "[acdfghijk]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m

--- a/internal/test_helpers/fixtures/end_of_string_anchor/success
+++ b/internal/test_helpers/fixtures/end_of_string_anchor/success
@@ -50,12 +50,12 @@
 [33m[tester::#RK3] [0m[92mTest passed.[0m
 
 [33m[tester::#TL6] [0m[94mRunning tests for Stage #TL6 (tl6)[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "a" | ./your_grep.sh -E "[abcd]"[0m
-[33m[your_program] [0ma
+[33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
+[33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 

--- a/internal/test_helpers/fixtures/end_of_string_anchor/success
+++ b/internal/test_helpers/fixtures/end_of_string_anchor/success
@@ -53,7 +53,7 @@
 [33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
 [33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "blueberry" | ./your_grep.sh -E "[acdfghijk]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m

--- a/internal/test_helpers/fixtures/end_of_string_anchor/success
+++ b/internal/test_helpers/fixtures/end_of_string_anchor/success
@@ -55,6 +55,8 @@
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 
 [33m[tester::#MR9] [0m[94mRunning tests for Stage #MR9 (mr9)[0m

--- a/internal/test_helpers/fixtures/negative_character_groups/success
+++ b/internal/test_helpers/fixtures/negative_character_groups/success
@@ -16,7 +16,7 @@
 [33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
 [33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "blueberry" | ./your_grep.sh -E "[acdfghijk]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m

--- a/internal/test_helpers/fixtures/negative_character_groups/success
+++ b/internal/test_helpers/fixtures/negative_character_groups/success
@@ -18,6 +18,8 @@
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 
 [33m[tester::#MR9] [0m[94mRunning tests for Stage #MR9 (mr9)[0m

--- a/internal/test_helpers/fixtures/negative_character_groups/success
+++ b/internal/test_helpers/fixtures/negative_character_groups/success
@@ -13,12 +13,12 @@
 [33m[tester::#RK3] [0m[92mTest passed.[0m
 
 [33m[tester::#TL6] [0m[94mRunning tests for Stage #TL6 (tl6)[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "a" | ./your_grep.sh -E "[abcd]"[0m
-[33m[your_program] [0ma
+[33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
+[33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 

--- a/internal/test_helpers/fixtures/one_or_more_quantifier/success
+++ b/internal/test_helpers/fixtures/one_or_more_quantifier/success
@@ -68,6 +68,8 @@
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 
 [33m[tester::#MR9] [0m[94mRunning tests for Stage #MR9 (mr9)[0m

--- a/internal/test_helpers/fixtures/one_or_more_quantifier/success
+++ b/internal/test_helpers/fixtures/one_or_more_quantifier/success
@@ -63,12 +63,12 @@
 [33m[tester::#RK3] [0m[92mTest passed.[0m
 
 [33m[tester::#TL6] [0m[94mRunning tests for Stage #TL6 (tl6)[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "a" | ./your_grep.sh -E "[abcd]"[0m
-[33m[your_program] [0ma
+[33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
+[33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 

--- a/internal/test_helpers/fixtures/one_or_more_quantifier/success
+++ b/internal/test_helpers/fixtures/one_or_more_quantifier/success
@@ -66,7 +66,7 @@
 [33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
 [33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "blueberry" | ./your_grep.sh -E "[acdfghijk]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m

--- a/internal/test_helpers/fixtures/positive_character_groups/success
+++ b/internal/test_helpers/fixtures/positive_character_groups/success
@@ -1,10 +1,10 @@
 [33m[tester::#TL6] [0m[94mRunning tests for Stage #TL6 (tl6)[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "a" | ./your_grep.sh -E "[abcd]"[0m
-[33m[your_program] [0ma
+[33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
+[33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 

--- a/internal/test_helpers/fixtures/positive_character_groups/success
+++ b/internal/test_helpers/fixtures/positive_character_groups/success
@@ -4,6 +4,8 @@
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 
 [33m[tester::#MR9] [0m[94mRunning tests for Stage #MR9 (mr9)[0m

--- a/internal/test_helpers/fixtures/positive_character_groups/success
+++ b/internal/test_helpers/fixtures/positive_character_groups/success
@@ -2,7 +2,7 @@
 [33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
 [33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "blueberry" | ./your_grep.sh -E "[acdfghijk]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m

--- a/internal/test_helpers/fixtures/start_of_string_anchor/success
+++ b/internal/test_helpers/fixtures/start_of_string_anchor/success
@@ -42,12 +42,12 @@
 [33m[tester::#RK3] [0m[92mTest passed.[0m
 
 [33m[tester::#TL6] [0m[94mRunning tests for Stage #TL6 (tl6)[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "a" | ./your_grep.sh -E "[abcd]"[0m
-[33m[your_program] [0ma
+[33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
+[33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 

--- a/internal/test_helpers/fixtures/start_of_string_anchor/success
+++ b/internal/test_helpers/fixtures/start_of_string_anchor/success
@@ -45,7 +45,7 @@
 [33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
 [33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "blueberry" | ./your_grep.sh -E "[acdfghijk]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m

--- a/internal/test_helpers/fixtures/start_of_string_anchor/success
+++ b/internal/test_helpers/fixtures/start_of_string_anchor/success
@@ -47,6 +47,8 @@
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 
 [33m[tester::#MR9] [0m[94mRunning tests for Stage #MR9 (mr9)[0m

--- a/internal/test_helpers/fixtures/wildcard/success
+++ b/internal/test_helpers/fixtures/wildcard/success
@@ -94,6 +94,8 @@
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 
 [33m[tester::#MR9] [0m[94mRunning tests for Stage #MR9 (mr9)[0m

--- a/internal/test_helpers/fixtures/wildcard/success
+++ b/internal/test_helpers/fixtures/wildcard/success
@@ -92,7 +92,7 @@
 [33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
 [33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "blueberry" | ./your_grep.sh -E "[acdfghijk]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m

--- a/internal/test_helpers/fixtures/wildcard/success
+++ b/internal/test_helpers/fixtures/wildcard/success
@@ -89,12 +89,12 @@
 [33m[tester::#RK3] [0m[92mTest passed.[0m
 
 [33m[tester::#TL6] [0m[94mRunning tests for Stage #TL6 (tl6)[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "a" | ./your_grep.sh -E "[abcd]"[0m
-[33m[your_program] [0ma
+[33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
+[33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 

--- a/internal/test_helpers/fixtures/zero_or_one_quantifier/success
+++ b/internal/test_helpers/fixtures/zero_or_one_quantifier/success
@@ -81,6 +81,8 @@
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 
 [33m[tester::#MR9] [0m[94mRunning tests for Stage #MR9 (mr9)[0m

--- a/internal/test_helpers/fixtures/zero_or_one_quantifier/success
+++ b/internal/test_helpers/fixtures/zero_or_one_quantifier/success
@@ -76,12 +76,12 @@
 [33m[tester::#RK3] [0m[92mTest passed.[0m
 
 [33m[tester::#TL6] [0m[94mRunning tests for Stage #TL6 (tl6)[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "a" | ./your_grep.sh -E "[abcd]"[0m
-[33m[your_program] [0ma
+[33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
+[33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "efgh" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[abcd]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[92mTest passed.[0m
 

--- a/internal/test_helpers/fixtures/zero_or_one_quantifier/success
+++ b/internal/test_helpers/fixtures/zero_or_one_quantifier/success
@@ -79,7 +79,7 @@
 [33m[tester::#TL6] [0m[94m$ echo -n "p" | ./your_grep.sh -E "[apple]"[0m
 [33m[your_program] [0mp
 [33m[tester::#TL6] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#TL6] [0m[94m$ echo -n "acdfghijk" | ./your_grep.sh -E "[blueberry]"[0m
+[33m[tester::#TL6] [0m[94m$ echo -n "blueberry" | ./your_grep.sh -E "[acdfghijk]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#TL6] [0m[94m$ echo -n "[]" | ./your_grep.sh -E "[strawberry]"[0m
 [33m[tester::#TL6] [0m[92m✓ Received exit code 1.[0m


### PR DESCRIPTION
Thanks to @grzadr for the feedback:

> I think the test for this step is flawed. If the implementation just looks for any character 
in the pattern it will past the challenge. For example it will match "[dog]".

> my point is that naive implementation will match "[dog]" with pattern "[abc]" since "[" is in the pattern. I am only writing this, because I passed the test without implementing support for that. I think there should be some negative test that check if strings with "[" or "]" are not matched.

**Fixture**

![image](https://github.com/user-attachments/assets/79ed9dbd-8e80-464e-9be2-efe855f8f24b)
