### PR TITLE
Replace double quotes with single quotes when pringting grep command

### DIFF
--- a/internal/test_cases/stdin_test_case.go
+++ b/internal/test_cases/stdin_test_case.go
@@ -21,7 +21,7 @@ func (c StdinTestCaseCollection) Run(stageHarness *test_case_harness.TestCaseHar
 	executable := stageHarness.Executable
 
 	for _, testCase := range c {
-		logger.Infof("$ echo -n \"%s\" | ./%s -E \"%s\"", testCase.Input, path.Base(executable.Path), testCase.Pattern)
+		logger.Infof("$ echo -n '%s' | ./%s -E '%s'", testCase.Input, path.Base(executable.Path), testCase.Pattern)
 
 		expectedResult := grep.EmulateGrep([]string{"-E", testCase.Pattern}, []byte(testCase.Input))
 		actualResult, err := executable.RunWithStdin([]byte(testCase.Input), "-E", testCase.Pattern)


### PR DESCRIPTION
Context:

https://forum.codecrafters.io/t/match-alphanumeric-characters-mr9-bash-expansion-causes-failed-tests/14247