### PR TITLE
Remove "$" from #mr9 alphanumeric

### DIFF
--- a/internal/stage_match_alphanumeric.go
+++ b/internal/stage_match_alphanumeric.go
@@ -14,7 +14,7 @@ func testMatchAlphanumeric(stageHarness *test_case_harness.TestCaseHarness) erro
 	RelocateSystemGrep(stageHarness)
 
 	words := random.RandomWords(2)
-	specialCharacters := []string{"+", "-", "÷", "×", "$", "€"}
+	specialCharacters := []string{"+", "-", "÷", "×", "=", "#", "%"}
 
 	nonWord1 := strings.Join(random.RandomElementsFromArray(specialCharacters, 3), "")
 	nonWord2 := strings.Join(random.RandomElementsFromArray(specialCharacters, 3), "")

--- a/internal/test_helpers/fixtures/base_stages/success
+++ b/internal/test_helpers/fixtures/base_stages/success
@@ -118,13 +118,13 @@
 [33m[tester::#MR9] [0m[94m$ echo -n "BANANA" | ./your_grep.sh -E "\w"[0m
 [33m[your_program] [0mBANANA
 [33m[tester::#MR9] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#MR9] [0m[94m$ echo -n "650" | ./your_grep.sh -E "\w"[0m
-[33m[your_program] [0m650
+[33m[tester::#MR9] [0m[94m$ echo -n "784" | ./your_grep.sh -E "\w"[0m
+[33m[your_program] [0m784
 [33m[tester::#MR9] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#MR9] [0m[94m$ echo -n "$+÷_-÷+" | ./your_grep.sh -E "\w"[0m
-[33m[your_program] [0m$+÷_-÷+
+[33m[tester::#MR9] [0m[94m$ echo -n "=+÷_#-+" | ./your_grep.sh -E "\w"[0m
+[33m[your_program] [0m=+÷_#-+
 [33m[tester::#MR9] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#MR9] [0m[94m$ echo -n "€-×+$÷" | ./your_grep.sh -E "\w"[0m
+[33m[tester::#MR9] [0m[94m$ echo -n "=%×÷-+" | ./your_grep.sh -E "\w"[0m
 [33m[tester::#MR9] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#MR9] [0m[92mTest passed.[0m
 


### PR DESCRIPTION
Context:

https://forum.codecrafters.io/t/match-alphanumeric-characters-mr9-bash-expansion-causes-failed-tests/14247