### PR TITLE
Add test case #zm7 Alternation 

### DIFF
--- a/internal/stage_alternation.go
+++ b/internal/stage_alternation.go
@@ -20,6 +20,11 @@ func testAlternation(stageHarness *test_case_harness.TestCaseHarness) error {
 			ExpectedExitCode: 1,
 		},
 		{
+			Pattern:          "a (cat|dog)",
+			Input:            "a cog",
+			ExpectedExitCode: 1,
+		},
+		{
 			Pattern:          "^I see \\d+ (cat|dog)s?$",
 			Input:            "I see 1 cat",
 			ExpectedExitCode: 0,

--- a/internal/stage_alternation.go
+++ b/internal/stage_alternation.go
@@ -16,7 +16,7 @@ func testAlternation(stageHarness *test_case_harness.TestCaseHarness) error {
 		},
 		{
 			// 'c', 'o', 'g' are all in {catdog}. This checks against quirky user logic.
-			// https://secure.helpscout.net/conversation/3091053263/9742?viewId=8414074
+			// https://secure.helpscout.net/conversation/3091053263/9742
 			Pattern:          "a (cat|dog)",
 			Input:            "a cog",
 			ExpectedExitCode: 1,

--- a/internal/stage_alternation.go
+++ b/internal/stage_alternation.go
@@ -15,11 +15,8 @@ func testAlternation(stageHarness *test_case_harness.TestCaseHarness) error {
 			ExpectedExitCode: 0,
 		},
 		{
-			Pattern:          "a (cat|dog)",
-			Input:            "a cow",
-			ExpectedExitCode: 1,
-		},
-		{
+			// 'c', 'o', 'g' are all in {catdog}. This checks against quirky user logic.
+			// https://secure.helpscout.net/conversation/3091053263/9742?viewId=8414074
 			Pattern:          "a (cat|dog)",
 			Input:            "a cog",
 			ExpectedExitCode: 1,

--- a/internal/test_helpers/fixtures/base_stages/success
+++ b/internal/test_helpers/fixtures/base_stages/success
@@ -4,6 +4,8 @@
 [33m[tester::#ZM7] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ZM7] [0m[94m$ echo -n 'a cow' | ./your_grep.sh -E 'a (cat|dog)'[0m
 [33m[tester::#ZM7] [0m[92m✓ Received exit code 1.[0m
+[33m[tester::#ZM7] [0m[94m$ echo -n 'a cog' | ./your_grep.sh -E 'a (cat|dog)'[0m
+[33m[tester::#ZM7] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#ZM7] [0m[94m$ echo -n 'I see 1 cat' | ./your_grep.sh -E '^I see \d+ (cat|dog)s?$'[0m
 [33m[your_program] [0mI see 1 cat
 [33m[tester::#ZM7] [0m[92m✓ Received exit code 0.[0m

--- a/internal/test_helpers/fixtures/base_stages/success
+++ b/internal/test_helpers/fixtures/base_stages/success
@@ -2,8 +2,6 @@
 [33m[tester::#ZM7] [0m[94m$ echo -n 'a cat' | ./your_grep.sh -E 'a (cat|dog)'[0m
 [33m[your_program] [0ma cat
 [33m[tester::#ZM7] [0m[92m✓ Received exit code 0.[0m
-[33m[tester::#ZM7] [0m[94m$ echo -n 'a cow' | ./your_grep.sh -E 'a (cat|dog)'[0m
-[33m[tester::#ZM7] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#ZM7] [0m[94m$ echo -n 'a cog' | ./your_grep.sh -E 'a (cat|dog)'[0m
 [33m[tester::#ZM7] [0m[92m✓ Received exit code 1.[0m
 [33m[tester::#ZM7] [0m[94m$ echo -n 'I see 1 cat' | ./your_grep.sh -E '^I see \d+ (cat|dog)s?$'[0m


### PR DESCRIPTION
Context:

https://secure.helpscout.net/conversation/3091053263/9742?viewId=8414074

<img width="1976" height="464" alt="image" src="https://github.com/user-attachments/assets/a3923066-4674-46d4-81c9-bbb85bff2b58" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the alternation stage test to use 'a cog' (not 'a cow') as the non-matching input and syncs the success fixture.
> 
> - **Tests**:
>   - Update `internal/stage_alternation.go`:
>     - Change stdin test case input from `a cow` to `a cog` for pattern `a (cat|dog)`.
>   - Sync fixture `internal/test_helpers/fixtures/base_stages/success` to reflect `a cog`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bd3ad182cf4adb1d058253d1cbeb074b8239437. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->