### PR TITLE
Update tester utils to pipe-pty-mixed branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/charmbracelet/ultraviolet v0.0.0-20251202162030-ecc8c1ae4b2b
 	github.com/charmbracelet/x/ansi v0.11.2
 	github.com/charmbracelet/x/vt v0.0.0-20251201173703-9f73bfd934ff
-	github.com/codecrafters-io/tester-utils v0.4.16-0.20260212080344-261d84f37c88
+	github.com/codecrafters-io/tester-utils v0.4.16
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/charmbracelet/ultraviolet v0.0.0-20251202162030-ecc8c1ae4b2b
 	github.com/charmbracelet/x/ansi v0.11.2
 	github.com/charmbracelet/x/vt v0.0.0-20251201173703-9f73bfd934ff
-	github.com/codecrafters-io/tester-utils v0.4.15
+	github.com/codecrafters-io/tester-utils v0.4.16-0.20260212074232-ae5c56d16bff
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/charmbracelet/ultraviolet v0.0.0-20251202162030-ecc8c1ae4b2b
 	github.com/charmbracelet/x/ansi v0.11.2
 	github.com/charmbracelet/x/vt v0.0.0-20251201173703-9f73bfd934ff
-	github.com/codecrafters-io/tester-utils v0.4.16-0.20260212080101-e9aafbb287cf
+	github.com/codecrafters-io/tester-utils v0.4.16-0.20260212080344-261d84f37c88
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/charmbracelet/ultraviolet v0.0.0-20251202162030-ecc8c1ae4b2b
 	github.com/charmbracelet/x/ansi v0.11.2
 	github.com/charmbracelet/x/vt v0.0.0-20251201173703-9f73bfd934ff
-	github.com/codecrafters-io/tester-utils v0.4.16-0.20260212074232-ae5c56d16bff
+	github.com/codecrafters-io/tester-utils v0.4.16-0.20260212080101-e9aafbb287cf
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
 )

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/clipperhouse/uax29/v2 v2.3.0 h1:SNdx9DVUqMoBuBoW3iLOj4FQv3dN5mDtuqwuh
 github.com/clipperhouse/uax29/v2 v2.3.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/codecrafters-io/tester-utils v0.4.15 h1:5scq/S1Eiz68yF+wcCIr59M5xWb/gLbrqvylwD2oDlc=
 github.com/codecrafters-io/tester-utils v0.4.15/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
+github.com/codecrafters-io/tester-utils v0.4.16-0.20260212074232-ae5c56d16bff h1:pffcDdtjYSkY66ui2D2IQcD1fydVBOMEtxSONgTfgVY=
+github.com/codecrafters-io/tester-utils v0.4.16-0.20260212074232-ae5c56d16bff/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/codecrafters-io/tester-utils v0.4.16-0.20260212080101-e9aafbb287cf h1
 github.com/codecrafters-io/tester-utils v0.4.16-0.20260212080101-e9aafbb287cf/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
 github.com/codecrafters-io/tester-utils v0.4.16-0.20260212080344-261d84f37c88 h1:GuGQ9XGyf4eVOz+slVkTy3b9r4zBB22InWl/IlXqaVY=
 github.com/codecrafters-io/tester-utils v0.4.16-0.20260212080344-261d84f37c88/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
+github.com/codecrafters-io/tester-utils v0.4.16 h1:IRMDLOy9n28zL62r1saRi/oxHQ6QCqwdk8dVnMT1KMY=
+github.com/codecrafters-io/tester-utils v0.4.16/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/codecrafters-io/tester-utils v0.4.15 h1:5scq/S1Eiz68yF+wcCIr59M5xWb/g
 github.com/codecrafters-io/tester-utils v0.4.15/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
 github.com/codecrafters-io/tester-utils v0.4.16-0.20260212074232-ae5c56d16bff h1:pffcDdtjYSkY66ui2D2IQcD1fydVBOMEtxSONgTfgVY=
 github.com/codecrafters-io/tester-utils v0.4.16-0.20260212074232-ae5c56d16bff/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
+github.com/codecrafters-io/tester-utils v0.4.16-0.20260212080101-e9aafbb287cf h1:YKmS8NUNgy9FcWObzdUmztACB7P/rQ4ZLs7k81xzLgI=
+github.com/codecrafters-io/tester-utils v0.4.16-0.20260212080101-e9aafbb287cf/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/codecrafters-io/tester-utils v0.4.16-0.20260212074232-ae5c56d16bff h1
 github.com/codecrafters-io/tester-utils v0.4.16-0.20260212074232-ae5c56d16bff/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
 github.com/codecrafters-io/tester-utils v0.4.16-0.20260212080101-e9aafbb287cf h1:YKmS8NUNgy9FcWObzdUmztACB7P/rQ4ZLs7k81xzLgI=
 github.com/codecrafters-io/tester-utils v0.4.16-0.20260212080101-e9aafbb287cf/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
+github.com/codecrafters-io/tester-utils v0.4.16-0.20260212080344-261d84f37c88 h1:GuGQ9XGyf4eVOz+slVkTy3b9r4zBB22InWl/IlXqaVY=
+github.com/codecrafters-io/tester-utils v0.4.16-0.20260212080344-261d84f37c88/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/stage_highlighting_auto.go
+++ b/internal/stage_highlighting_auto.go
@@ -30,9 +30,9 @@ func testHighlightingAutoOption(stageHarness *test_case_harness.TestCaseHarness)
 				animals[0] + " in the wild",
 				animals[1] + " in the air",
 			},
-			ExpectedExitCode: 0,
-			ColorMode:        utils.ColorAlways,
-			RunInsideTty:     true,
+			ExpectedExitCode:        0,
+			ColorMode:               utils.ColorAlways,
+			UseTtyBasedOutputStream: true,
 		},
 
 		// Two never option tests
@@ -43,11 +43,11 @@ func testHighlightingAutoOption(stageHarness *test_case_harness.TestCaseHarness)
 			ColorMode:        utils.ColorNever,
 		},
 		{
-			Pattern:          fruit,
-			InputLines:       []string{"I love " + fruit},
-			ExpectedExitCode: 0,
-			ColorMode:        utils.ColorNever,
-			RunInsideTty:     true,
+			Pattern:                 fruit,
+			InputLines:              []string{"I love " + fruit},
+			ExpectedExitCode:        0,
+			ColorMode:               utils.ColorNever,
+			UseTtyBasedOutputStream: true,
 		},
 
 		// Two auto option tests (matching)
@@ -58,11 +58,11 @@ func testHighlightingAutoOption(stageHarness *test_case_harness.TestCaseHarness)
 			ColorMode:        utils.ColorAuto,
 		},
 		{
-			Pattern:          animals[1],
-			InputLines:       []string{"The " + animals[1] + " runs fast"},
-			ExpectedExitCode: 0,
-			ColorMode:        utils.ColorAuto,
-			RunInsideTty:     true,
+			Pattern:                 animals[1],
+			InputLines:              []string{"The " + animals[1] + " runs fast"},
+			ExpectedExitCode:        0,
+			ColorMode:               utils.ColorAuto,
+			UseTtyBasedOutputStream: true,
 		},
 		// One non-matching test case as well
 		{
@@ -70,9 +70,9 @@ func testHighlightingAutoOption(stageHarness *test_case_harness.TestCaseHarness)
 			InputLines: []string{
 				"no numbers here",
 			},
-			ExpectedExitCode: 1,
-			ColorMode:        utils.ColorAuto,
-			RunInsideTty:     true,
+			ExpectedExitCode:        1,
+			ColorMode:               utils.ColorAuto,
+			UseTtyBasedOutputStream: true,
 		},
 	}
 

--- a/internal/stage_highlighting_auto.go
+++ b/internal/stage_highlighting_auto.go
@@ -30,9 +30,9 @@ func testHighlightingAutoOption(stageHarness *test_case_harness.TestCaseHarness)
 				animals[0] + " in the wild",
 				animals[1] + " in the air",
 			},
-			ExpectedExitCode:        0,
-			ColorMode:               utils.ColorAlways,
-			UseTtyBasedOutputStream: true,
+			ExpectedExitCode:          0,
+			ColorMode:                 utils.ColorAlways,
+			ShouldUseTtyOutputStreams: true,
 		},
 
 		// Two never option tests
@@ -43,11 +43,11 @@ func testHighlightingAutoOption(stageHarness *test_case_harness.TestCaseHarness)
 			ColorMode:        utils.ColorNever,
 		},
 		{
-			Pattern:                 fruit,
-			InputLines:              []string{"I love " + fruit},
-			ExpectedExitCode:        0,
-			ColorMode:               utils.ColorNever,
-			UseTtyBasedOutputStream: true,
+			Pattern:                   fruit,
+			InputLines:                []string{"I love " + fruit},
+			ExpectedExitCode:          0,
+			ColorMode:                 utils.ColorNever,
+			ShouldUseTtyOutputStreams: true,
 		},
 
 		// Two auto option tests (matching)
@@ -58,11 +58,11 @@ func testHighlightingAutoOption(stageHarness *test_case_harness.TestCaseHarness)
 			ColorMode:        utils.ColorAuto,
 		},
 		{
-			Pattern:                 animals[1],
-			InputLines:              []string{"The " + animals[1] + " runs fast"},
-			ExpectedExitCode:        0,
-			ColorMode:               utils.ColorAuto,
-			UseTtyBasedOutputStream: true,
+			Pattern:                   animals[1],
+			InputLines:                []string{"The " + animals[1] + " runs fast"},
+			ExpectedExitCode:          0,
+			ColorMode:                 utils.ColorAuto,
+			ShouldUseTtyOutputStreams: true,
 		},
 		// One non-matching test case as well
 		{
@@ -70,9 +70,9 @@ func testHighlightingAutoOption(stageHarness *test_case_harness.TestCaseHarness)
 			InputLines: []string{
 				"no numbers here",
 			},
-			ExpectedExitCode:        1,
-			ColorMode:               utils.ColorAuto,
-			UseTtyBasedOutputStream: true,
+			ExpectedExitCode:          1,
+			ColorMode:                 utils.ColorAuto,
+			ShouldUseTtyOutputStreams: true,
 		},
 	}
 

--- a/internal/test_cases/highlighting_test_case.go
+++ b/internal/test_cases/highlighting_test_case.go
@@ -70,7 +70,7 @@ func (c HighlightingTestCaseCollection) Run(stageHarness *test_case_harness.Test
 		var actualResult executable.ExecutableResult
 		var err error
 
-		grepExecutable.ShouldUsePty = testCase.RunInsideTty
+		grepExecutable.ShouldUsePtyOutputStreams = testCase.RunInsideTty
 
 		actualResult, err = grepExecutable.RunWithStdin([]byte(allInputLines), allArguments...)
 

--- a/internal/test_cases/highlighting_test_case.go
+++ b/internal/test_cases/highlighting_test_case.go
@@ -13,11 +13,11 @@ import (
 )
 
 type HighlightingTestCase struct {
-	Pattern                 string
-	InputLines              []string
-	ExpectedExitCode        int
-	UseTtyBasedOutputStream bool
-	ColorMode               utils.ColorMode
+	Pattern                   string
+	InputLines                []string
+	ExpectedExitCode          int
+	ShouldUseTtyOutputStreams bool
+	ColorMode                 utils.ColorMode
 }
 
 type HighlightingTestCaseCollection []HighlightingTestCase
@@ -45,7 +45,7 @@ func (c HighlightingTestCaseCollection) Run(stageHarness *test_case_harness.Test
 		allArguments = append(allArguments, []string{"-E", testCase.Pattern}...)
 		pipeToCat := ""
 
-		if !testCase.UseTtyBasedOutputStream {
+		if !testCase.ShouldUseTtyOutputStreams {
 			pipeToCat = "| cat"
 		}
 
@@ -59,7 +59,7 @@ func (c HighlightingTestCaseCollection) Run(stageHarness *test_case_harness.Test
 		// Emulate grep
 		emulatedResult := grep.EmulateGrep(allArguments, grep.EmulationOptions{
 			Stdin:        []byte(allInputLines),
-			EmulateInTTY: testCase.UseTtyBasedOutputStream,
+			EmulateInTTY: testCase.ShouldUseTtyOutputStreams,
 		})
 
 		// Verify expected code against emulated result
@@ -70,7 +70,7 @@ func (c HighlightingTestCaseCollection) Run(stageHarness *test_case_harness.Test
 		var actualResult executable.ExecutableResult
 		var err error
 
-		grepExecutable.ShouldUsePtyOutputStreams = testCase.UseTtyBasedOutputStream
+		grepExecutable.ShouldUsePtyOutputStreams = testCase.ShouldUseTtyOutputStreams
 
 		actualResult, err = grepExecutable.RunWithStdin([]byte(allInputLines), allArguments...)
 

--- a/internal/test_cases/highlighting_test_case.go
+++ b/internal/test_cases/highlighting_test_case.go
@@ -13,11 +13,11 @@ import (
 )
 
 type HighlightingTestCase struct {
-	Pattern          string
-	InputLines       []string
-	ExpectedExitCode int
-	RunInsideTty     bool
-	ColorMode        utils.ColorMode
+	Pattern                 string
+	InputLines              []string
+	ExpectedExitCode        int
+	UseTtyBasedOutputStream bool
+	ColorMode               utils.ColorMode
 }
 
 type HighlightingTestCaseCollection []HighlightingTestCase
@@ -45,7 +45,7 @@ func (c HighlightingTestCaseCollection) Run(stageHarness *test_case_harness.Test
 		allArguments = append(allArguments, []string{"-E", testCase.Pattern}...)
 		pipeToCat := ""
 
-		if !testCase.RunInsideTty {
+		if !testCase.UseTtyBasedOutputStream {
 			pipeToCat = "| cat"
 		}
 
@@ -59,7 +59,7 @@ func (c HighlightingTestCaseCollection) Run(stageHarness *test_case_harness.Test
 		// Emulate grep
 		emulatedResult := grep.EmulateGrep(allArguments, grep.EmulationOptions{
 			Stdin:        []byte(allInputLines),
-			EmulateInTTY: testCase.RunInsideTty,
+			EmulateInTTY: testCase.UseTtyBasedOutputStream,
 		})
 
 		// Verify expected code against emulated result
@@ -70,7 +70,7 @@ func (c HighlightingTestCaseCollection) Run(stageHarness *test_case_harness.Test
 		var actualResult executable.ExecutableResult
 		var err error
 
-		grepExecutable.ShouldUsePtyOutputStreams = testCase.RunInsideTty
+		grepExecutable.ShouldUsePtyOutputStreams = testCase.UseTtyBasedOutputStream
 
 		actualResult, err = grepExecutable.RunWithStdin([]byte(allInputLines), allArguments...)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small dependency bump plus a straightforward rename/behavioral alignment of test harness flags; limited to test execution behavior and unlikely to affect production logic.
> 
> **Overview**
> Bumps `github.com/codecrafters-io/tester-utils` from `v0.4.15` to `v0.4.16` (updating `go.sum` accordingly).
> 
> Updates the highlighting auto stage/test harness to replace `RunInsideTty`/`ShouldUsePty` with the newer `ShouldUseTtyOutputStreams`/`ShouldUsePtyOutputStreams`, changing how tests decide between TTY-style output streams vs piping through `cat` while keeping expected behavior the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c884bdc9216a7ac3d8d9596c252679490eb9f81b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->